### PR TITLE
Remove dash from custom api params

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,11 +1,11 @@
 {
 	"name" : "CustomLogs",
-	"version" : "0.1",
+	"version" : "1.0.0",
 	"author" : [
 		"Megan Cutrofello",
 		"Brian Wolff"
 	],
-	"url" : "https://lol.gamepedia.com/User:RheingoldRiver/CustomLogs_Help",
+	"url" : "https://www.mediawiki.org/wiki/Extension:CustomLogs",
 	"descriptionmsg": "customlogs-desc",
 	"license-name": "GPL-2.0-or-later",
 	"MessagesDirs" : {

--- a/includes/ApiCustomLogWriter.php
+++ b/includes/ApiCustomLogWriter.php
@@ -50,7 +50,7 @@ class ApiCustomLogWriter extends ApiBase {
 	const CUSTOM_PARAM_PREFIX = 'custom';
 	
 	private static function getApiParamFromIndex($i) {
-		$index = self::CUSTOM_PARAM_PREFIX . '-' . strval($i + 1);
+		$index = self::CUSTOM_PARAM_PREFIX . strval($i + 1);
 		return $index;
 	}
 	


### PR DESCRIPTION
This is a breaking change from before, but the previous naming was very inconvenient when using custom params as arguments in e.g. Python functions, so I think it's worth the change.

With this update I'm also incrementing to a stable release number, since I've been using this for over 2 years now and this addresses my only real complaint with the extension.