### PR TITLE
Add `manifest_version` field to `extension.json`

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,7 @@
 {
 	"name" : "CustomLogs",
 	"version" : "1.1.0",
+	"manifest_version": 1,
 	"author" : [
 		"Megan Cutrofello",
 		"Brian Wolff"


### PR DESCRIPTION
Missing `manifest_version` field in `extension.json` was causing unwanted deprecation warning in logs and worrying errors during migrations. This is not severe, but I'm fixing this while I remember about the issue