### PR TITLE
[1.39 compatibility] default to empty string summary

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name" : "CustomLogs",
-	"version" : "1.1.0",
+	"version" : "1.1.1",
 	"manifest_version": 1,
 	"author" : [
 		"Megan Cutrofello",

--- a/includes/ApiCustomLogWriter.php
+++ b/includes/ApiCustomLogWriter.php
@@ -82,7 +82,9 @@ class ApiCustomLogWriter extends ApiBase {
 			'pageid' => [
 				ParamValidator::PARAM_TYPE => 'integer'
 			],
-			'summary' => null,
+			'summary' => [
+                                ParamValidator::PARAM_DEFAULT => ''
+                        ],
 			'tags' => [
 				ParamValidator::PARAM_TYPE => 'tags',
 				ParamValidator::PARAM_ISMULTI => true,

--- a/includes/ApiCustomLogWriter.php
+++ b/includes/ApiCustomLogWriter.php
@@ -83,8 +83,8 @@ class ApiCustomLogWriter extends ApiBase {
 				ParamValidator::PARAM_TYPE => 'integer'
 			],
 			'summary' => [
-                                ParamValidator::PARAM_DEFAULT => ''
-                        ],
+				ParamValidator::PARAM_DEFAULT => ''
+			],
 			'tags' => [
 				ParamValidator::PARAM_TYPE => 'tags',
 				ParamValidator::PARAM_ISMULTI => true,


### PR DESCRIPTION
I think at some point setComment stopped taking null values and now only likes strings, if we don't pass the summary to the API request it returns this:
```
{
    "error": {
        "code": "internal_api_error_TypeError",
        "info": "[39fea66d2a087474] Caught exception of type TypeError",
        "errorclass": "TypeError"
    }
}
```
Then we can make the summary param an empty string if its not passed to the request